### PR TITLE
Add per-interface RRD support

### DIFF
--- a/initdb.sh
+++ b/initdb.sh
@@ -1,6 +1,9 @@
+#!/usr/bin/env bash
+
+NAME="${1:-pf.rrd}"
 rrdtool \
 	create \
-	pf.rrd \
+	"${NAME}" \
 	--step 1 \
 	DS:bytes_in:DERIVE:10:U:U \
 	DS:bytes_out:DERIVE:10:U:U \


### PR DESCRIPTION
## Summary
- allow specifying RRD file and interface list via flags
- track per-interface counters
- write separate RRD files for each interface

## Testing
- `make pfstatsd` *(fails: net/pfvar.h not found)*

------
https://chatgpt.com/codex/tasks/task_b_68779931013c8332876568bb1c821976